### PR TITLE
Implement dog catalog pages

### DIFF
--- a/src/main/java/com/board/bulldogs/controller/DogController.java
+++ b/src/main/java/com/board/bulldogs/controller/DogController.java
@@ -1,4 +1,32 @@
 package com.board.bulldogs.controller;
 
+import com.board.bulldogs.service.DogService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
 public class DogController {
+    private final DogService dogService;
+
+    public DogController(DogService dogService) {
+        this.dogService = dogService;
+    }
+
+    @GetMapping("/dogs")
+    public String listDogs(Model model) {
+        model.addAttribute("dogs", dogService.findAll());
+        return "dogs";
+    }
+
+    @GetMapping("/dogs/{id}")
+    public String dogDetails(@PathVariable Long id, Model model) {
+        var dog = dogService.findById(id).orElse(null);
+        if (dog == null) {
+            return "redirect:/dogs";
+        }
+        model.addAttribute("dog", dog);
+        return "dog-details";
+    }
 }

--- a/src/main/java/com/board/bulldogs/model/Dog.java
+++ b/src/main/java/com/board/bulldogs/model/Dog.java
@@ -1,4 +1,33 @@
 package com.board.bulldogs.model;
 
+import java.util.List;
+
 public class Dog {
+    private Long id;
+    private String name;
+    private String bio;
+    private List<String> imagePaths;
+
+    public Dog(Long id, String name, String bio, List<String> imagePaths) {
+        this.id = id;
+        this.name = name;
+        this.bio = bio;
+        this.imagePaths = imagePaths;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public List<String> getImagePaths() {
+        return imagePaths;
+    }
 }

--- a/src/main/java/com/board/bulldogs/service/DogService.java
+++ b/src/main/java/com/board/bulldogs/service/DogService.java
@@ -1,4 +1,36 @@
 package com.board.bulldogs.service;
 
+import com.board.bulldogs.model.Dog;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
 public class DogService {
+    private final List<Dog> dogs = new ArrayList<>();
+
+    @PostConstruct
+    public void init() {
+        dogs.add(new Dog(1L, "Max", "Friendly English Bulldog", List.of(
+                "/images/bulldog1.jpg",
+                "/images/bulldog2.jpg",
+                "/images/bulldog3.jpg"
+        )));
+        dogs.add(new Dog(2L, "Bella", "Playful French Bulldog", List.of(
+                "/images/bulldog2.jpg",
+                "/images/bulldog3.jpg",
+                "/images/bulldog1.jpg"
+        )));
+    }
+
+    public List<Dog> findAll() {
+        return dogs;
+    }
+
+    public Optional<Dog> findById(Long id) {
+        return dogs.stream().filter(d -> d.getId().equals(id)).findFirst();
+    }
 }

--- a/src/main/resources/templates/dog-details.html
+++ b/src/main/resources/templates/dog-details.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="${dog.name}">Dog Details</title>
+    <link rel="stylesheet" href="/css/styles.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body>
+<header>
+    <h1 th:text="${dog.name}">Dog Name</h1>
+</header>
+<main class="container mt-3">
+    <div id="dogCarousel" class="carousel slide mb-4" data-bs-ride="carousel">
+        <div class="carousel-inner" th:each="img, iterStat : ${dog.imagePaths}">
+            <div class="carousel-item" th:classappend="${iterStat.index == 0}? ' active'">
+                <img th:src="${img}" class="d-block w-100" alt="Dog image">
+            </div>
+        </div>
+        <button class="carousel-control-prev" type="button" data-bs-target="#dogCarousel" data-bs-slide="prev">
+            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+            <span class="visually-hidden">Previous</span>
+        </button>
+        <button class="carousel-control-next" type="button" data-bs-target="#dogCarousel" data-bs-slide="next">
+            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+            <span class="visually-hidden">Next</span>
+        </button>
+    </div>
+
+    <p th:text="${dog.bio}">Dog bio</p>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/dogs.html
+++ b/src/main/resources/templates/dogs.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Dogs</title>
+    <link rel="stylesheet" href="/css/styles.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<header>
+    <h1>Available Dogs</h1>
+</header>
+<main class="container mt-3">
+    <div class="row" th:each="dog : ${dogs}">
+        <div class="col-md-4 mb-4">
+            <div class="card h-100">
+                <img th:src="${dog.imagePaths[0]}" class="card-img-top" alt="Dog image">
+                <div class="card-body">
+                    <h5 class="card-title" th:text="${dog.name}">Dog Name</h5>
+                    <p class="card-text" th:text="${dog.bio}">Dog bio</p>
+                    <a th:href="@{'/dogs/' + ${dog.id}}" class="btn btn-primary">View Details</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,28 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Board Bulldogs - Home</title>
     <link rel="stylesheet" href="/css/styles.css">
-    <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
-
-    <!-- Bootstrap Bundle with Popper -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
-
     <style>
-        /* Custom styles */
         .carousel-section {
-            max-width: 800px; /* Set a max width for the carousel */
-            margin: 0 auto; /* Center the carousel */
-            padding-bottom: 20px; /* Add some space between the carousel and footer */
+            max-width: 800px;
+            margin: 0 auto;
+            padding-bottom: 20px;
         }
         .carousel-item img {
-            max-height: 400px; /* Set a max height for the images */
-            object-fit: cover; /* Ensure images cover the area without distortion */
-            width: 100%; /* Make sure the images are responsive */
+            max-height: 400px;
+            object-fit: cover;
+            width: 100%;
         }
         footer {
-            text-align: center; /* Center-align the footer text */
-            padding: 10px 0; /* Add some padding to the footer */
-            background-color: #f8f9fa; /* Optional: Add a background color to the footer */
+            text-align: center;
+            padding: 10px 0;
+            background-color: #f8f9fa;
         }
     </style>
 </head>
@@ -43,14 +38,12 @@
     </nav>
 </header>
 <main>
-    <!-- Hero Section -->
     <section class="hero">
         <h2>Your Perfect Bulldog Awaits</h2>
         <p>Find your new best friend from our selection of beautiful bulldogs.</p>
         <a href="/dogs" class="btn btn-primary">View Available Dogs</a>
     </section>
 
-    <!-- Carousel Section -->
     <section class="carousel-section">
         <div id="bulldogCarousel" class="carousel slide" data-bs-ride="carousel">
             <div class="carousel-indicators">
@@ -80,7 +73,6 @@
         </div>
     </section>
 
-    <!-- Featured Dogs Section -->
     <section class="featured-dogs">
         <h3>Featured Bulldogs</h3>
         <div class="dog-list">


### PR DESCRIPTION
## Summary
- add `Dog` model to hold simple dog data
- implement `DogService` with in-memory list of dog entries
- add `DogController` endpoints for listing and detail views
- create Thymeleaf templates for listing dogs in cards and detailed carousel view
- clean up `index.html`

## Testing
- `./gradlew test` *(fails: Java toolchain missing)*

------
https://chatgpt.com/codex/tasks/task_e_688ac952f6e88325a949228d41526c89