### PR TITLE
Add Thymeleaf templates, styling, and Maven config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.0</version>
+        <relativePath/>
+    </parent>
+    <groupId>com.board</groupId>
+    <artifactId>bulldogs</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>bulldogs</name>
+    <description>Bulldog puppies website</description>
+    
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -1,79 +1,337 @@
-body {
-    font-family: Arial, sans-serif;
+/* Reset and Base Styles */
+* {
     margin: 0;
     padding: 0;
-    background-color: #f4f4f4;
+    box-sizing: border-box;
 }
 
+body {
+    font-family: 'Arial', sans-serif;
+    line-height: 1.6;
+    color: #333;
+    background-color: #f9f9f9;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+/* Header and Navigation */
 header {
-    background-color: #333;
+    background: linear-gradient(135deg, #8B4513, #D2691E);
     color: white;
-    padding: 1rem;
+    padding: 1rem 0;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
 }
 
-header h1 {
-    margin: 0;
+nav .container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+nav h1 a {
+    color: white;
+    text-decoration: none;
+    font-size: 1.8rem;
+    font-weight: bold;
 }
 
 nav ul {
-    list-style-type: none;
-    padding: 0;
-}
-
-nav ul li {
-    display: inline;
-    margin-right: 15px;
+    display: flex;
+    list-style: none;
+    gap: 2rem;
 }
 
 nav ul li a {
     color: white;
     text-decoration: none;
+    font-weight: 500;
+    transition: opacity 0.3s;
 }
 
+nav ul li a:hover {
+    opacity: 0.8;
+}
+
+/* Hero Section */
 .hero {
-    background-color: #0066cc;
+    background: linear-gradient(rgba(139, 69, 19, 0.8), rgba(210, 105, 30, 0.8)), 
+                url('/images/hero-bg.jpg') center/cover;
     color: white;
-    padding: 2rem;
     text-align: center;
+    padding: 6rem 0;
 }
 
-.hero h2 {
-    margin: 0;
+.hero h1 {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+    text-shadow: 2px 2px 4px rgba(0,0,0,0.5);
 }
 
 .hero p {
-    margin-top: 0.5rem;
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
-.btn {
+.cta-button {
     display: inline-block;
-    padding: 0.5rem 1rem;
+    background: #FF6B35;
     color: white;
-    background-color: #333;
+    padding: 1rem 2rem;
     text-decoration: none;
-    border-radius: 5px;
-    margin-top: 1rem;
+    border-radius: 50px;
+    font-weight: bold;
+    font-size: 1.1rem;
+    transition: all 0.3s;
+    box-shadow: 0 4px 15px rgba(255, 107, 53, 0.3);
 }
 
-.featured-dogs {
+.cta-button:hover {
+    background: #E55A2B;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(255, 107, 53, 0.4);
+}
+
+/* Features Section */
+.features {
+    padding: 4rem 0;
+    background: white;
+}
+
+.features h2 {
+    text-align: center;
+    margin-bottom: 3rem;
+    color: #8B4513;
+    font-size: 2.5rem;
+}
+
+.features-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+}
+
+.feature {
+    text-align: center;
+    padding: 2rem;
+    border-radius: 10px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+    transition: transform 0.3s;
+}
+
+.feature:hover {
+    transform: translateY(-5px);
+}
+
+.feature h3 {
+    color: #D2691E;
+    margin-bottom: 1rem;
+    font-size: 1.5rem;
+}
+
+/* Dogs Grid */
+.dogs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    margin: 2rem 0;
+}
+
+.dog-card {
+    background: white;
+    border-radius: 15px;
+    overflow: hidden;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+    transition: all 0.3s;
+}
+
+.dog-card:hover {
+    transform: translateY(-10px);
+    box-shadow: 0 20px 40px rgba(0,0,0,0.15);
+}
+
+.dog-image {
+    height: 250px;
+    overflow: hidden;
+}
+
+.dog-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s;
+}
+
+.dog-card:hover .dog-image img {
+    transform: scale(1.1);
+}
+
+.dog-info {
+    padding: 1.5rem;
+}
+
+.dog-info h3 {
+    color: #8B4513;
+    margin-bottom: 0.5rem;
+    font-size: 1.5rem;
+}
+
+.dog-info p {
+    color: #666;
+    margin-bottom: 1rem;
+    line-height: 1.5;
+}
+
+.view-details-btn {
+    background: #FF6B35;
+    color: white;
+    padding: 0.75rem 1.5rem;
+    text-decoration: none;
+    border-radius: 25px;
+    font-weight: bold;
+    transition: all 0.3s;
+    display: inline-block;
+}
+
+.view-details-btn:hover {
+    background: #E55A2B;
+    transform: translateY(-2px);
+}
+
+/* Dog Details Page */
+.dog-details {
+    background: white;
+    margin: 2rem 0;
+    border-radius: 15px;
+    overflow: hidden;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+}
+
+.back-link {
+    padding: 1rem 2rem;
+    background: #f8f8f8;
+    border-bottom: 1px solid #eee;
+}
+
+.back-link a {
+    color: #8B4513;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.dog-detail-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
     padding: 2rem;
 }
 
-.dog-list {
-    display: flex;
-    justify-content: space-around;
+.image-gallery {
+    display: grid;
+    gap: 1rem;
 }
 
-.dog {
+.gallery-item img {
+    width: 100%;
+    height: 300px;
+    object-fit: cover;
+    border-radius: 10px;
+}
+
+.dog-info h1 {
+    color: #8B4513;
+    font-size: 2.5rem;
+    margin-bottom: 1rem;
+}
+
+.dog-bio {
+    margin-bottom: 2rem;
+}
+
+.dog-bio h3 {
+    color: #D2691E;
+    margin-bottom: 0.5rem;
+}
+
+.contact-info {
+    background: #f8f8f8;
+    padding: 1.5rem;
+    border-radius: 10px;
+}
+
+.contact-info h3 {
+    color: #8B4513;
+    margin-bottom: 1rem;
+}
+
+.contact-btn, .inquire-btn {
+    background: #FF6B35;
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 25px;
+    font-weight: bold;
+    margin-right: 1rem;
+    margin-top: 1rem;
+    cursor: pointer;
+    transition: all 0.3s;
+}
+
+.contact-btn:hover, .inquire-btn:hover {
+    background: #E55A2B;
+    transform: translateY(-2px);
+}
+
+.inquire-btn {
+    background: #8B4513;
+}
+
+.inquire-btn:hover {
+    background: #654321;
+}
+
+/* No Dogs Message */
+.no-dogs {
     text-align: center;
+    padding: 4rem 2rem;
+    color: #666;
 }
 
+/* Footer */
 footer {
-    background-color: #333;
+    background: #8B4513;
     color: white;
     text-align: center;
-    padding: 1rem;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
+    padding: 2rem 0;
+    margin-top: 4rem;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .hero h1 {
+        font-size: 2rem;
+    }
+    
+    .hero p {
+        font-size: 1rem;
+    }
+    
+    .dog-detail-content {
+        grid-template-columns: 1fr;
+    }
+    
+    nav .container {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    
+    nav ul {
+        gap: 1rem;
+    }
 }

--- a/src/main/resources/static/images/hero-bg.jpg
+++ b/src/main/resources/static/images/hero-bg.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/src/main/resources/templates/dog-details.html
+++ b/src/main/resources/templates/dog-details.html
@@ -1,34 +1,63 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title th:text="${dog.name}">Dog Details</title>
-    <link rel="stylesheet" href="/css/styles.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${dog.name} + ' - Bulldog Puppies'">Dog Details</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
 </head>
 <body>
-<header>
-    <h1 th:text="${dog.name}">Dog Name</h1>
-</header>
-<main class="container mt-3">
-    <div id="dogCarousel" class="carousel slide mb-4" data-bs-ride="carousel">
-        <div class="carousel-inner" th:each="img, iterStat : ${dog.imagePaths}">
-            <div class="carousel-item" th:classappend="${iterStat.index == 0}? ' active'">
-                <img th:src="${img}" class="d-block w-100" alt="Dog image">
+    <header>
+        <nav>
+            <div class="container">
+                <h1><a th:href="@{/}">🐕 Bulldog Puppies</a></h1>
+                <ul>
+                    <li><a th:href="@{/}">Home</a></li>
+                    <li><a th:href="@{/dogs}">Available Puppies</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <main>
+        <div class="container">
+            <div class="dog-details">
+                <div class="back-link">
+                    <a th:href="@{/dogs}">← Back to All Puppies</a>
+                </div>
+                
+                <div class="dog-detail-content">
+                    <div class="dog-images">
+                        <div class="image-gallery">
+                            <div th:each="imagePath : ${dog.imagePaths}" class="gallery-item">
+                                <img th:src="@{${imagePath}}" th:alt="${dog.name}" />
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="dog-info">
+                        <h1 th:text="${dog.name}">Dog Name</h1>
+                        <div class="dog-bio">
+                            <h3>About This Puppy</h3>
+                            <p th:text="${dog.bio}">Dog biography</p>
+                        </div>
+                        
+                        <div class="contact-info">
+                            <h3>Interested?</h3>
+                            <p>Contact us to learn more about this adorable puppy!</p>
+                            <button class="contact-btn">📞 Contact Us</button>
+                            <button class="inquire-btn">💌 Send Inquiry</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
-        <button class="carousel-control-prev" type="button" data-bs-target="#dogCarousel" data-bs-slide="prev">
-            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Previous</span>
-        </button>
-        <button class="carousel-control-next" type="button" data-bs-target="#dogCarousel" data-bs-slide="next">
-            <span class="carousel-control-next-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Next</span>
-        </button>
-    </div>
+    </main>
 
-    <p th:text="${dog.bio}">Dog bio</p>
-</main>
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 Bulldog Puppies. All rights reserved.</p>
+        </div>
+    </footer>
 </body>
 </html>

--- a/src/main/resources/templates/dogs.html
+++ b/src/main/resources/templates/dogs.html
@@ -1,28 +1,51 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Dogs</title>
-    <link rel="stylesheet" href="/css/styles.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Available Puppies - Bulldog Puppies</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
 </head>
 <body>
-<header>
-    <h1>Available Dogs</h1>
-</header>
-<main class="container mt-3">
-    <div class="row" th:each="dog : ${dogs}">
-        <div class="col-md-4 mb-4">
-            <div class="card h-100">
-                <img th:src="${dog.imagePaths[0]}" class="card-img-top" alt="Dog image">
-                <div class="card-body">
-                    <h5 class="card-title" th:text="${dog.name}">Dog Name</h5>
-                    <p class="card-text" th:text="${dog.bio}">Dog bio</p>
-                    <a th:href="@{'/dogs/' + ${dog.id}}" class="btn btn-primary">View Details</a>
+    <header>
+        <nav>
+            <div class="container">
+                <h1><a th:href="@{/}">🐕 Bulldog Puppies</a></h1>
+                <ul>
+                    <li><a th:href="@{/}">Home</a></li>
+                    <li><a th:href="@{/dogs}">Available Puppies</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
+
+    <main>
+        <div class="container">
+            <h1>Available Puppies</h1>
+            
+            <div class="dogs-grid">
+                <div th:each="dog : ${dogs}" class="dog-card">
+                    <div class="dog-image">
+                        <img th:src="@{${dog.imagePaths[0]}}" th:alt="${dog.name}" />
+                    </div>
+                    <div class="dog-info">
+                        <h3 th:text="${dog.name}">Dog Name</h3>
+                        <p th:text="${dog.bio}">Dog bio</p>
+                        <a th:href="@{/dogs/{id}(id=${dog.id})}" class="view-details-btn">View Details</a>
+                    </div>
                 </div>
             </div>
+            
+            <div th:if="${#lists.isEmpty(dogs)}" class="no-dogs">
+                <p>No puppies available at the moment. Please check back later!</p>
+            </div>
         </div>
-    </div>
-</main>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 Bulldog Puppies. All rights reserved.</p>
+        </div>
+    </footer>
 </body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,92 +1,58 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Board Bulldogs - Home</title>
-    <link rel="stylesheet" href="/css/styles.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
-    <style>
-        .carousel-section {
-            max-width: 800px;
-            margin: 0 auto;
-            padding-bottom: 20px;
-        }
-        .carousel-item img {
-            max-height: 400px;
-            object-fit: cover;
-            width: 100%;
-        }
-        footer {
-            text-align: center;
-            padding: 10px 0;
-            background-color: #f8f9fa;
-        }
-    </style>
+    <title>Bulldog Puppies for Sale</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
 </head>
 <body>
-<header>
-    <h1>Welcome to Board Bulldogs</h1>
-    <nav>
-        <ul>
-            <li><a href="/">Home</a></li>
-            <li><a href="/about">About</a></li>
-            <li><a href="/dogs">Available Dogs</a></li>
-            <li><a href="/contact">Contact</a></li>
-        </ul>
-    </nav>
-</header>
-<main>
-    <section class="hero">
-        <h2>Your Perfect Bulldog Awaits</h2>
-        <p>Find your new best friend from our selection of beautiful bulldogs.</p>
-        <a href="/dogs" class="btn btn-primary">View Available Dogs</a>
-    </section>
+    <header>
+        <nav>
+            <div class="container">
+                <h1><a th:href="@{/}">🐕 Bulldog Puppies</a></h1>
+                <ul>
+                    <li><a th:href="@{/}">Home</a></li>
+                    <li><a th:href="@{/dogs}">Available Puppies</a></li>
+                </ul>
+            </div>
+        </nav>
+    </header>
 
-    <section class="carousel-section">
-        <div id="bulldogCarousel" class="carousel slide" data-bs-ride="carousel">
-            <div class="carousel-indicators">
-                <button type="button" data-bs-target="#bulldogCarousel" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
-                <button type="button" data-bs-target="#bulldogCarousel" data-bs-slide-to="1" aria-label="Slide 2"></button>
-                <button type="button" data-bs-target="#bulldogCarousel" data-bs-slide-to="2" aria-label="Slide 3"></button>
+    <main>
+        <section class="hero">
+            <div class="container">
+                <h1>Premium Bulldog Puppies for Sale</h1>
+                <p>Find your perfect furry companion from our selection of healthy, well-socialized bulldog puppies.</p>
+                <a th:href="@{/dogs}" class="cta-button">View Available Puppies</a>
             </div>
-            <div class="carousel-inner">
-                <div class="carousel-item active">
-                    <img src="/images/bulldog1.jpg" class="d-block w-100" alt="Bulldog 1">
-                </div>
-                <div class="carousel-item">
-                    <img src="/images/bulldog2.jpg" class="d-block w-100" alt="Bulldog 2">
-                </div>
-                <div class="carousel-item">
-                    <img src="/images/bulldog3.jpg" class="d-block w-100" alt="Bulldog 3">
-                </div>
-            </div>
-            <button class="carousel-control-prev" type="button" data-bs-target="#bulldogCarousel" data-bs-slide="prev">
-                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                <span class="visually-hidden">Previous</span>
-            </button>
-            <button class="carousel-control-next" type="button" data-bs-target="#bulldogCarousel" data-bs-slide="next">
-                <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                <span class="visually-hidden">Next</span>
-            </button>
-        </div>
-    </section>
+        </section>
 
-    <section class="featured-dogs">
-        <h3>Featured Bulldogs</h3>
-        <div class="dog-list">
-            <div class="dog">
-                <img src="/images/bulldog1.jpg" alt="Sample Dog">
-                <h4>Max</h4>
-                <p>Breed: English Bulldog</p>
-                <a href="/dogs/1" class="btn btn-secondary">View Details</a>
+        <section class="features">
+            <div class="container">
+                <h2>Why Choose Our Bulldogs?</h2>
+                <div class="features-grid">
+                    <div class="feature">
+                        <h3>🏆 Champion Bloodlines</h3>
+                        <p>All our puppies come from carefully selected champion bloodlines.</p>
+                    </div>
+                    <div class="feature">
+                        <h3>❤️ Health Guaranteed</h3>
+                        <p>Every puppy comes with health certificates and genetic testing.</p>
+                    </div>
+                    <div class="feature">
+                        <h3>🎓 Well Socialized</h3>
+                        <p>Our puppies are raised in a loving home environment with proper socialization.</p>
+                    </div>
+                </div>
             </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 Bulldog Puppies. All rights reserved.</p>
         </div>
-    </section>
-</main>
-<footer>
-    <p>&copy; 2024 Board Bulldogs. All rights reserved.</p>
-</footer>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Introduce landing page with hero and feature highlights
- Add templates for listing and viewing individual puppies
- Provide responsive CSS styles and Maven pom with Thymeleaf

## Testing
- `./gradlew test` *(fails: missing Java 17 toolchain)*
- `apt-get update` *(fails: repository 403, unable to install JDK 17)*

------
https://chatgpt.com/codex/tasks/task_e_688ff6a0c2b48325854b1da0cb2616a2