### PR TITLE
Add Render deployment configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: bulldog-puppies
+    env: java
+    buildCommand: mvn clean package -DskipTests
+    startCommand: java -jar target/bulldogs-0.0.1-SNAPSHOT.jar
+    plan: free


### PR DESCRIPTION
## Summary
- add Render deployment settings for bulldog-puppies service

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_68914365f2a88325968f5710e7c1e6c2